### PR TITLE
allow higher local versions when checking for online versions

### DIFF
--- a/Sources/versionchecker.cpp
+++ b/Sources/versionchecker.cpp
@@ -52,7 +52,7 @@ void VersionChecker::replyFinished(QNetworkReply *reply)
             emit pDebug("Installed AT Free: " + VERSION + " - Latest AT Free: " + latestVersion);
         }
 
-        if(VERSION == latestVersion)
+        if(VERSION >= latestVersion)
         {
             emit pLog("Settings: Arena Tracker is up-to-date.");
             emit pDebug("Arena Tracker is up-to-date.");


### PR DESCRIPTION
When using the github master (so a higher local version than newest github release), the update check mechanism forces you to downgrade or at least will close the mainwindow.