### PR TITLE
Correctly identify Whizbang heroes and import player deck

### DIFF
--- a/Sources/deckhandler.cpp
+++ b/Sources/deckhandler.cpp
@@ -1576,8 +1576,12 @@ bool DeckHandler::newDeck(bool reset)
 
 void DeckHandler::importDeckString()
 {
+    importDeckString(QApplication::clipboard()->text());
+}
+
+void DeckHandler::importDeckString(QString text)
+{
     QString deckName;
-    QString text = QApplication::clipboard()->text();
     QList<CodeAndCount> deckList = DeckStringHandler::readDeckString(text, deckName);
 
     if(deckList.isEmpty())

--- a/Sources/deckhandler.cpp
+++ b/Sources/deckhandler.cpp
@@ -1573,6 +1573,19 @@ bool DeckHandler::newDeck(bool reset)
     return true;
 }
 
+void DeckHandler::whizbangDeck(QString code)
+{
+    QString deckString = Utility::whizbangDeckString(code);
+    if(deckString.isEmpty())
+    {
+        emit showMessageProgressBar("Unknown whizbang deck " + code);
+        emit pDebug("Unknown whizbang deck " + code);
+    }
+    else
+    {
+        importDeckString(deckString);
+    }
+}
 
 void DeckHandler::importDeckString()
 {

--- a/Sources/deckhandler.h
+++ b/Sources/deckhandler.h
@@ -118,6 +118,7 @@ signals:
     void pDebug(QString line, DebugLevel debugLevel=Normal, QString file="DeckHandler");
 
 public slots:
+    void whizbangDeck(QString code);
     void newDeckCardAsset(QString code);
     void newDeckCardDraft(QString code);
     void newDeckCardWeb(QString code, int total);

--- a/Sources/deckhandler.h
+++ b/Sources/deckhandler.h
@@ -74,6 +74,7 @@ private:
     void addNewDeckMenu(QPushButton *button);
     bool newDeck(bool reset);
     void importDeckString();
+    void importDeckString(QString deck);
     void importEnemyDeck();
     void hideUnknown(bool hidden = true);
     QString getCodeFromDraftLogLine(QString line);

--- a/Sources/gamewatcher.cpp
+++ b/Sources/gamewatcher.cpp
@@ -1127,6 +1127,12 @@ void GameWatcher::processZone(QString &line, qint64 numLine)
                     playerTag = (playerID == 1)?name1:name2;
                     if(!playerTag.isEmpty())    emit pDebug("Found playerTag: " + playerTag, numLine);
                 }
+                QString& whizbang = (playerID == 1)?whizbang1:whizbang2;
+                if(!whizbang.isEmpty())
+                {
+                    emit whizbangDeck(whizbang);
+                    emit pDebug("Found whizbang deck: " + whizbang, numLine);
+                }
             }
             emit playerHeroZonePlayAdd(cardId, id.toInt());
         }

--- a/Sources/gamewatcher.h
+++ b/Sources/gamewatcher.h
@@ -59,7 +59,7 @@ private:
     PowerState powerState;
     ArenaState arenaState;
     LoadingScreenState loadingScreenState;
-    QString hero1, hero2, name1, name2, firstPlayer, winnerPlayer;
+    QString hero1, hero2, whizbang1, whizbang2, name1, name2, firstPlayer, winnerPlayer;
     int playerID;
     CardClass secretHero;
     int enemyMinions, enemyMinionsAliveForAvenge; //Avenge control
@@ -87,6 +87,7 @@ private:
     void processAsset(QString &line, qint64 numLine);
     void processArena(QString &line, qint64 numLine);
     void processPower(QString &line, qint64 numLine, qint64 logSeek);
+    void processPowerHero(QString &line, qint64 numLine);
     void processPowerMulligan(QString &line, qint64 numLine);
     void processPowerInGame(QString &line, qint64 numLine);
     void processZone(QString &line, qint64 numLine);

--- a/Sources/gamewatcher.h
+++ b/Sources/gamewatcher.h
@@ -109,6 +109,7 @@ signals:
     void arenaChoosingHeroe();
     void inRewards();
     void newDeckCard(QString card);
+    void whizbangDeck(QString code);
     void startGame();
     void endGame(bool playerWon=false, bool playerUnknown=true);
     void enemyHero(QString hero);

--- a/Sources/mainwindow.cpp
+++ b/Sources/mainwindow.cpp
@@ -956,6 +956,8 @@ void MainWindow::createGameWatcher()
             deckHandler, SLOT(returnToDeck(QString, int)));
     connect(gameWatcher, SIGNAL(clearDrawList(bool)),
             deckHandler, SLOT(clearDrawList(bool)));
+    connect(gameWatcher, SIGNAL(whizbangDeck(QString)),
+            deckHandler, SLOT(whizbangDeck(QString)));
     connect(gameWatcher, SIGNAL(startGame()),
             deckHandler, SLOT(lockDeckInterface()));
     connect(gameWatcher, SIGNAL(endGame(bool,bool)),

--- a/Sources/utility.cpp
+++ b/Sources/utility.cpp
@@ -102,6 +102,20 @@ QString Utility::heroString2FromLogNumber(QString hero)
 }
 
 
+CardClass Utility::whizbangHero(QString code)
+{
+    if(code == QString("1606") || code == QString("1829"))       return DRUID;
+    else if(code == QString("1607") || code == QString("1828"))  return HUNTER;
+    else if(code == QString("1609") || code == QString("1832"))  return MAGE;
+    else if(code == QString("1754") || code == QString("1825"))  return PALADIN;
+    else if(code == QString("1830") || code == QString("1831"))  return PRIEST;
+    else if(code == QString("1820") || code == QString("1821"))  return ROGUE;
+    else if(code == QString("1826") || code == QString("1827"))  return SHAMAN;
+    else if(code == QString("1818") || code == QString("1819"))  return WARLOCK;
+    else if(code == QString("1760") || code == QString("1817"))  return WARRIOR;
+    else                                                         return INVALID_CLASS;
+}
+
 //Return info about heroes in alphabetical order
 QString Utility::getHeroColor(int order)
 {

--- a/Sources/utility.cpp
+++ b/Sources/utility.cpp
@@ -101,6 +101,28 @@ QString Utility::heroString2FromLogNumber(QString hero)
     else                            return "";
 }
 
+QString Utility::whizbangDeckString(QString code)
+{
+    if     (code == QString("1606")) return "### Out of the Woods\nAAECAZICBMnCAofOAsLOApnTAg1AX8QG5AiU0gKY0gKo0gKL4QKE5gKL5gL15wLf+wLo/AIA";               // Recruit Druid
+    else if(code == QString("1607")) return "### I Hunt Alone\nAAECAR8EhwTp0gKG0wLy6gINjQGoArUDyQSXCNsJ/gzd0gLf0gLj0gLh4wLq4wKH+wIA";                       // Spell Hunter
+    else if(code == QString("1609")) return "### Spells are fun, SO FUN!\nAAECAf0EBNACvwib0wKj6wINTYoByQPsB/sMysMClscCx8cC29MC1eEC1+ECluQC1+sCAA==";        // Big Spells Mage
+    else if(code == QString("1754")) return "### Greymane's Alliance\nAAECAZ8FBvoGucEC4fACzfQC6/cC/fsCDNwD9AXPBq8HsQizwQKIxwLZxwKbywK35wL27ALZ/gIA";        // Even Paladin
+    else if(code == QString("1760")) return "### The Gilneas Armory\nAAECAQcIqgbTwwKZxwLN7wKb8AKe+AKO+wKggAMLS5EDogT/B5vCAsrDAqLHAsrnAqrsArrsAvLxAgA=";     // Odd Warrior
+    else if(code == QString("1817")) return "### The Boomsday Project\nAAECAQcEze8Cm/ACkvgCoIADDZEGzM0CuuwCnfACl/MCn/UCpfUC5PcCjvgCg/sCqPsCs/wCzIEDAA==";   // Rush Warrior
+    else if(code == QString("1818")) return "### Demonology Lab\nAAECAf0GApfTAo+CAw4w9wTCCPYIm8sC980C8dAC8tAC9PcC0/gCqvkCt/0Cw/0C+v4CAA==";                 // Zoolock
+    else if(code == QString("1819")) return "### The Omega Project\nAAECAf0GApfTApz4Ag6KAbYHxAjnywLy0AL40AKI0gL85QLq5gLo5wK38QLF8wL8+gKPgAMA";              // Control Warlock
+    else if(code == QString("1820")) return "### Stolen Research\nAAECAaIHBLICgNMC6/ACqPcCDbQBywObBYYJgcIC68ICm8gC5dEC2+MC6vMCt/UCovcCx/gCAA==";            // Thief Rogue
+    else if(code == QString("1821")) return "### The Necrium Trials\nAAECAaIHCIwC7QX7BeXRAs/hAvDmAtjpAp/4Agu0AYHCAqvCAuvCAtvjAurmArT2At76Auz8Avb9AtGBAwA="; // N'Zoth Rogue
+    else if(code == QString("1825")) return "### Kangor's Endless Army\nAAECAZ8FBvQFzwb6BrnBAvH+AqCAAwzcA48Js8EC48sCn/UCpfUC1v4C2f4C4f4CkYAD0YADzIEDAA==";  // Control Paladin
+    else if(code == QString("1826")) return "### Witchwood Awoken\nAAECAaoICooB7QXAB8/HApvLAsLOAqrsAqfuAoH2Ap79AgqBBPUE/gX/BcfBAvPnApbvAvbwAoqAA5eAAwA=";   // Control Shaman
+    else if(code == QString("1827")) return "### The Storm Bringer\nAAECAaoIBMAH88ICofgCmfsCDb0B+QOGBvAHkwnrwgKw8AL28AKz9wLq+gKP+wKc/wKKgAMA";              // Midrange Shaman
+    else if(code == QString("1828")) return "### Flark's Fireworks\nAAECAR8C4fUCoIADDo0Bigbh4wKf9QLg9QLi9QLv9QKZ9wK5+AKR+wKY+wKE/QL2/QLMgQMA";              // Mech Hunter
+    else if(code == QString("1829")) return "### Trees Are Friends\nAAECAZICAiTF/QIO/QLtA/cD5gWxCIbBAqTCAuvCAtfvAsHzAt/7AuH7Ar/9AtWDAwA=";                  // Token Druid
+    else if(code == QString("1830")) return "### Quest For Immortality\nAAECAa0GBMnCApbEAsv4Ao2CAw37AeUE0wryDKvCAubMAvDPAujQAovhAoL3AqH+AvX+AoiCAwA=";      // Quest Priest
+    else if(code == QString("1831")) return "### Awesome Augmentation\nAAECAa0GBKIJvsgC2OMCy/gCDfgC5QSNCNEK8gzRwQLYwQLL5gKC9wLl9wL1/gLxgAPeggMA";           // Lyra Combo Priest
+    else if(code == QString("1832")) return "### Shooting Starts\nAAECAf0EAqLTAu72Ag67ApUDvwOrBLQElgW/wQL77AKS7wK89wKj/QKV/wK5/wLvgAMA";                    // Tempo Mage
+    else                             return "";
+}
 
 CardClass Utility::whizbangHero(QString code)
 {

--- a/Sources/utility.h
+++ b/Sources/utility.h
@@ -86,6 +86,7 @@ public:
     static QString getHeroColor(int order);
     static QString getHeroName(int order);
     static QString getHeroLogNumber(int order);
+    static CardClass whizbangHero(QString code);
     static QJsonValue getCardAttribute(QString code, QString attribute);
     static QString appPath();
     static QString dataPath();

--- a/Sources/utility.h
+++ b/Sources/utility.h
@@ -86,6 +86,7 @@ public:
     static QString getHeroColor(int order);
     static QString getHeroName(int order);
     static QString getHeroLogNumber(int order);
+    static QString whizbangDeckString(QString code);
     static CardClass whizbangHero(QString code);
     static QJsonValue getCardAttribute(QString code, QString attribute);
     static QString appPath();


### PR DESCRIPTION
Apparently, the Power log contains a random hero first, which is then later switched out for the selected whizbang hero. This means that the game gets totally confused about what heroes are playing. This additionally maps the whizbang deck codes to deck strings, so that you can see all cards at your disposal when playing a (supported) whizbang deck.

This uses a hardcoded list of deck codes (which will have to be updated for each new expansion) for mapping both decks and heroes. It might be possible to do this in a better way by discerning heroes and deck by using the Power log, but I assumed that would be complicated, and after retrieving all the deck strings, the mapping was relatively simple.

Technically, I have done very limited play testing after setting up the mapping, but it seemed to work reasonably well with the limited tests that I did.

In terms of implementation, I tried to stay faithful to the existing code style, and put the code where it made the most sense, but there might be better ways to solve this.