### PR TITLE
Update cards.json

### DIFF
--- a/CardsJson/cardsVersion.json
+++ b/CardsJson/cardsVersion.json
@@ -1,3 +1,3 @@
 {
-  "cardsVersion": 20
+  "cardsVersion": 21
 }

--- a/Sources/mainwindow.cpp
+++ b/Sources/mainwindow.cpp
@@ -4933,7 +4933,7 @@ void MainWindow::testDelay()
     // Utility::setTrustHA(false);//Si necesitamos revisar HATL antes de modificar arena.json a no trust en la rotacion nueva
     // checkHearthArenaTLCodes(false);//Ahora (no trustHA) / 1 semana despues (si trustHA) / ("EDR_001" --> "CORE_EDR_001") es incorrecto
 
-    // testDownloadCardsJson();///v1/229984
+    // testDownloadCardsJson();///v1/240397
     // testDownloadRotation(true/*, "DINO_"*/);//Force hearthpwn true
     // Utility::resizeSignatureCards();
 


### PR DESCRIPTION
Sync cards.json with HearthstoneJSON build v1/240397 (dated 2026-04-16), the latest upstream snapshot. Bump cardsVersion 20 -> 21 and update the tracking comment in mainwindow.cpp accordingly.

Adds the missing cards from the latest set so newer deck codes (e.g. the Year of the Scarab expansion: Black Blood, Ruby Sanctum, Purifying Breath, Cleansing Cleric, Medivh's Triumph, Devouring Plague, Eternal Firebolt, etc.) resolve correctly and stop producing 'Invalid HS deck' on import.